### PR TITLE
Readd locales after they were fixed with https://github.com/brave/ele…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-# Electron Installer
-
-[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/nxhep80va4d7afjb/branch/master?svg=true)](https://ci.appveyor.com/project/kevinsawicki/windows-installer/branch/master)
-[![Travis CI Build Status](https://travis-ci.org/electron/windows-installer.svg?branch=master)](https://travis-ci.org/electronjs/windows-installer)
+# Muon Installer
 
 NPM module that builds Windows installers for
-[Electron](https://github.com/atom/electron) apps using
+[Muon](https://github.com/brave/electron) (Brave's fork of [Electron](https://github.com/atom/electron))
+apps using
 [Squirrel](https://github.com/Squirrel/Squirrel.Windows).
 
 ## Installing
 
 ```sh
-npm install --save-dev electron-winstaller
+npm install --save-dev muon-winstaller
 ```
 
 ## Usage
@@ -18,13 +16,13 @@ npm install --save-dev electron-winstaller
 Require the package:
 
 ```js
-var electronInstaller = require('electron-winstaller');
+var muonInstaller = require('muon-winstaller');
 ```
 
 Then do a build like so..
 
 ```js
-resultPromise = electronInstaller.createWindowsInstaller({
+resultPromise = muonInstaller.createWindowsInstaller({
     appDirectory: '/tmp/build/my-app-64',
     outputDirectory: '/tmp/build/installer64',
     authors: 'My App Inc.',
@@ -42,7 +40,7 @@ There are several configuration settings supported:
 
 | Config Name           | Required | Description |
 | --------------------- | -------- | ----------- |
-| `appDirectory`        | Yes      | The folder path of your Electron app |
+| `appDirectory`        | Yes      | The folder path of your Muon app |
 | `outputDirectory`     | No       | The folder path to create the `.exe` installer in. Defaults to the `installer` folder at the project root. |
 | `loadingGif`          | No       | The local path to a `.gif` file to display during install. |
 | `authors`             | Yes      | The authors value for the nuget package metadata. Defaults to the `author` field from your app's package.json file when unspecified. |

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "electron-winstaller",
-  "version": "2.4.0",
-  "description": "Module to generate Windows installers for Electron apps",
+  "name": "muon-winstaller",
+  "version": "2.4.1",
+  "description": "Module to generate Windows installers for Muon apps (the Brave fork of Electron)",
   "main": "./lib/index.js",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/electronjs/windows-installer"
+    "url": "https://github.com/brave/muon-winstaller"
   },
   "scripts": {
     "compile": "babel -d lib/ src/",

--- a/template.nuspectemplate
+++ b/template.nuspectemplate
@@ -12,6 +12,7 @@
     <copyright><%- copyright %></copyright>
   </metadata>
   <files>
+    <file src="locales\**" target="lib\net45\locales" />
     <file src="resources\**" target="lib\net45\resources" />
     <file src="*.bin" target="lib\net45" />
     <file src="*.dll" target="lib\net45" />


### PR DESCRIPTION
- Readd locales after they were fixed with https://github.com/brave/electron/commit/a1ef630bbf055e170d8d5e2b70f3ba36e993356d
- rename electron => muon in package.json and readme.md
- Bump to version 2.4.1

cc: @bbondy @bridiver 

If this is accepted, do we need to publish to NPM?  browser-laptop doesn't reference this package by the git repo:
https://github.com/brave/browser-laptop/blob/chromium54/package.json#L156